### PR TITLE
DL-1779: changed number.of.periods to tax.quarters.multiplier

### DIFF
--- a/app/utils/TFCSchemeConfig.scala
+++ b/app/utils/TFCSchemeConfig.scala
@@ -82,7 +82,7 @@ class TFCConfig @Inject()(val config: CCConfig) {
     )
   }
 
-  def tfcNoOfPeriods: Short = config.oldConf.getInt("tfc.number.of.periods").getOrElse(4).toShort
+  def tfcNoOfPeriods: Short = config.oldConf.getInt("tax.quarters.multiplier").getOrElse(4).toShort
 
   def getConfig(currentDate: LocalDate, location: String): TFCTaxYearConfig = {
     val configs: Seq[Configuration] = config.oldConf.getConfigSeq("tfc.rule-change").get

--- a/conf/config-tfc.conf
+++ b/conf/config-tfc.conf
@@ -14,7 +14,7 @@
 
 # The configuration file for tfc scheme variables. Updating the values does not require to re-deploy the service.
 tfc {
-  number.of.periods = 4
+  tax.quarters.multiplier = 4
   rule-change = [
     {
       rule-date : 06-04-2019

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -15,11 +15,11 @@ private object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    hmrc %% "bootstrap-play-26" % "0.37.0",
-    hmrc %% "govuk-template" % "5.30.0-play-26",
-    hmrc %% "play-ui" % "7.33.0-play-26",
+    hmrc %% "bootstrap-play-26" % "0.38.0",
+    hmrc %% "govuk-template" % "5.31.0-play-26",
+    hmrc %% "play-ui" % "7.38.0-play-26",
     "com.github.fge" % "json-schema-validator" % "2.2.6",
-    "com.kenshoo" %% "metrics-play" % "2.3.0_0.1.8",
+    "com.kenshoo" %% "metrics-play" % "2.3.0_0.2.1",
     typesafe %% "play-json" % "2.6.13",
     typesafe %% "play-json-joda" % "2.6.13"
   )
@@ -32,11 +32,11 @@ private object AppDependencies {
   object Test {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test = Seq(
-        "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % scope,
-        "org.scalatest" %% "scalatest" % "3.0.0" % scope,
+        "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % scope,
+        "org.scalatest" %% "scalatest" % "3.0.7" % scope,
         hmrc %% "hmrctest" % "3.6.0-play-26" % scope,
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
-        "org.mockito" % "mockito-core" % "2.18.3" % scope,
+        "org.mockito" % "mockito-core" % "2.27.0" % scope,
         typesafe %% "play-test" % PlayVersion.current % scope
       )
     }.test


### PR DESCRIPTION
# DL-1799

**Bug fix**

As per the discussions form the live incident review, I have changed the name of the value in the config file from number.of.periods to tax.quarters.multiplier in order to make it clearer what the value is used for.
## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
