### PR TITLE
Fix "Unparseable Date" error in certain configurations

### DIFF
--- a/app/eligibility/TFCEligibility.scala
+++ b/app/eligibility/TFCEligibility.scala
@@ -24,7 +24,6 @@ import service.AuditEvents
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.TFCConfig
 
-import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.util.{Calendar, Date}
 import javax.inject.Inject
@@ -57,15 +56,13 @@ class TFCEligibility @Inject()(auditEvent: AuditEvents,
     childBirthdayCalendar.setTime(childBirthday) // childs date of birth
     val septemberCalendar = Calendar.getInstance()
     septemberCalendar.clear()
-    var endWeekOf1stSeptember = firstOfSeptember(septemberCalendar, childBirthday, childBirthdayCalendar) // end date of first week of 1st september
+    val endWeekOf1stSeptember = firstOfSeptember(septemberCalendar, childBirthday, childBirthdayCalendar) // end date of first week of 1st september
 
     if (endWeekOf1stSeptember.before(childBirthday) || childBirthday.equals(endWeekOf1stSeptember)) { // end week is before today
       septemberCalendar.add(Calendar.YEAR, 1) // must be next year (september now+1)
     }
 
-    endWeekOf1stSeptember = getWeekEnd(septemberCalendar)
-    val dateFormatter = new SimpleDateFormat("E MMM dd HH:mm:ss z yyyy")
-    dateFormatter.parse(endWeekOf1stSeptember.toString)
+    getWeekEnd(septemberCalendar)
   }
 
   def getChildBirthday(periodStart: LocalDate, location: String, child: TFCChild): Date ={

--- a/test/eligibility/TFCEligibilitySpec.scala
+++ b/test/eligibility/TFCEligibilitySpec.scala
@@ -53,7 +53,7 @@ class TFCEligibilitySpec extends FakeCCEligibilityApplication with PrivateMethod
       ccConfig.toLocalDate(child11Birthday) shouldBe LocalDate.parse("2016-08-27", formatter)
     }
 
-    "determine childs Birthday (11th or 16th) where child is disabled" in {
+    "determine child's Birthday (11th or 16th) where child is disabled" in {
       val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
       val dateOfBirth = LocalDate.parse("2000-09-27", formatter)
       val current = LocalDate.parse("2017-08-01", formatter)
@@ -587,7 +587,6 @@ class TFCEligibilitySpec extends FakeCCEligibilityApplication with PrivateMethod
           qualifying = false,
           from = None,
           until = None,
-         
           BigDecimal(200.00),
           childcareCostPeriod=Periods.Monthly,
           models.output.tfc.TFCDisability(false,false)


### PR DESCRIPTION
In certain configurations, default Locale had different
date and time format than defined for SimpleDateFormat in
TFCEligibility.endWeek1stOfSeptemberDate method.

I realised however, that the parsing which is causing problems,
is actually not necessary. It is parsing a Date object converted
to String, only to return Date object representing the same date.

I removed this parsing and now the method returns the
original Date object.
All Unit Tests pass, as well as all Acceptance Tests.